### PR TITLE
Changed delay values and removed code not appropriate for Sam's model…

### DIFF
--- a/arduino/firmware_ams/firmware_ams.ino
+++ b/arduino/firmware_ams/firmware_ams.ino
@@ -303,7 +303,7 @@ static void setPenAngle(int pen_angle) {
     if(posz>PEN_UP_ANGLE  ) posz=PEN_UP_ANGLE;
 
     s1.write( (int)posz );
-    delay(200);
+    delay(500);
   }
 }
 


### PR DESCRIPTION
… robot, changed step delay to 20ms hardcoded.  Works, ugly.  
We debugged this and did a test print, and changing the delays to a 200ms with a delay() function eliminated the jitter that was causing problems.  

The motherboard in this case is specialized, and the other motherboard compile options are not maintained, so they can be removed.  